### PR TITLE
FAB-30: Add Cardinality Check for Text Fields

### DIFF
--- a/python-da/dq-checks/src/data_quality_checker.py
+++ b/python-da/dq-checks/src/data_quality_checker.py
@@ -13,3 +13,11 @@ class DataQualityChecker:
     
     def count_duplicate_values(self) -> int:
         return self.dataset.duplicated().sum()
+
+    def count_unique_values_in_text_fields(self) -> dict:
+        unique_values = {}
+        for col in self.dataset.columns:
+            if self.dataset[col].dtype == 'object':  # Checking if the col is a text field
+                unique_count = self.dataset[col].nunique()  # Counting number of unique values
+                unique_values[col] = unique_count
+        return unique_values

--- a/python-da/dq-checks/tests/test_data_quality_checker.py
+++ b/python-da/dq-checks/tests/test_data_quality_checker.py
@@ -6,17 +6,23 @@ from src.data_quality_checker import DataQualityChecker
 data = {
     'A': [1, 2, None, 4, 1, 5, 5],  
     'B': [None, 2, 3, 4, 2, None, None],  
-    'C': [1, 2, 3, 4, 1, 5, 5]    
+    'C': [1, 2, 3, 4, 1, 5, 5],
+    'D': ['Cat', 'Dog', 'Cat', 'Cow', None, 'Dog', 'Dog'],
+    'E': ['Bike', None, 'Bus', 'Car', None, 'Train', 'Train']
 }
 
+
 # Expected result for missing values count
-expected_missing_values_result = {'A': 1, 'B': 3, 'C': 0}
+expected_missing_values_result = {'A': 1, 'B': 3, 'C': 0, 'D': 1, 'E': 2}
 
 # Expected result for number of records count
 expected_records_count = 7
 
 # Expected result for duplicate values count
 expected_duplicate_values_count = 1  
+
+# Expected result for unique values count in text fields
+expected_unique_values_result = {'D': 3, 'E': 4}
 
 # Fixture to initialize DataQualityChecker with sample data
 @pytest.fixture
@@ -35,3 +41,7 @@ def test_count_number_of_records(checker):
 # Test function to check count_duplicate_values method
 def test_count_duplicate_values(checker):
     assert checker.count_duplicate_values() == expected_duplicate_values_count
+
+# Test function to check count_unique_values_in_text_fields method
+def test_count_unique_values_in_text_fields(checker):
+    assert checker.count_unique_values_in_text_fields() == expected_unique_values_result


### PR DESCRIPTION
- Implemented cardinality data profiling check. The check only checks text fields.
- Implemented unit test for check.
- Edit unit test dataset to add new fields which have text data.
- This check provides users with insight into the cardinality of text fields in their datasets, which is crucial for understanding data distribution and making informed preprocessing decisions for machine learning.